### PR TITLE
Tightened up imperfect emulation flag / tweaked logging

### DIFF
--- a/Mamesaver/ConfigForm.Designer.cs
+++ b/Mamesaver/ConfigForm.Designer.cs
@@ -78,7 +78,7 @@ namespace Mamesaver
             this.label9 = new System.Windows.Forms.Label();
             this.tabPage4 = new System.Windows.Forms.TabPage();
             this.debugLogging = new System.Windows.Forms.CheckBox();
-            this.skipGameValidation = new System.Windows.Forms.CheckBox();
+            this.includeImperfectEmulation = new System.Windows.Forms.CheckBox();
             this.resetToDefaults = new System.Windows.Forms.Button();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
@@ -547,7 +547,7 @@ namespace Mamesaver
             // tabPage4
             // 
             this.tabPage4.Controls.Add(this.debugLogging);
-            this.tabPage4.Controls.Add(this.skipGameValidation);
+            this.tabPage4.Controls.Add(this.includeImperfectEmulation);
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
             this.tabPage4.Size = new System.Drawing.Size(440, 337);
@@ -565,15 +565,15 @@ namespace Mamesaver
             this.debugLogging.Text = "Debug logging";
             this.debugLogging.UseVisualStyleBackColor = true;
             // 
-            // skipGameValidation
+            // includeImperfectEmulation
             // 
-            this.skipGameValidation.AutoSize = true;
-            this.skipGameValidation.Location = new System.Drawing.Point(9, 17);
-            this.skipGameValidation.Name = "skipGameValidation";
-            this.skipGameValidation.Size = new System.Drawing.Size(124, 17);
-            this.skipGameValidation.TabIndex = 0;
-            this.skipGameValidation.Text = "Skip game validation";
-            this.skipGameValidation.UseVisualStyleBackColor = true;
+            this.includeImperfectEmulation.AutoSize = true;
+            this.includeImperfectEmulation.Location = new System.Drawing.Point(9, 17);
+            this.includeImperfectEmulation.Name = "includeImperfectEmulation";
+            this.includeImperfectEmulation.Size = new System.Drawing.Size(211, 17);
+            this.includeImperfectEmulation.TabIndex = 0;
+            this.includeImperfectEmulation.Text = "Include games with imperfect emulation";
+            this.includeImperfectEmulation.UseVisualStyleBackColor = true;
             // 
             // resetToDefaults
             // 
@@ -673,6 +673,6 @@ namespace Mamesaver
         private System.Windows.Forms.ProgressBar gameListProgress;
         private System.Windows.Forms.TabPage tabPage4;
         private System.Windows.Forms.CheckBox debugLogging;
-        private System.Windows.Forms.CheckBox skipGameValidation;
+        private System.Windows.Forms.CheckBox includeImperfectEmulation;
     }
 }

--- a/Mamesaver/ConfigForm.cs
+++ b/Mamesaver/ConfigForm.cs
@@ -103,7 +103,7 @@ namespace Mamesaver
 
             // Advanced
             debugLogging.Checked = _advancedSettings.DebugLogging;
-            skipGameValidation.Checked = _advancedSettings.SkipGameValidation;
+            includeImperfectEmulation.Checked = _advancedSettings.IncludeImperfectEmulation;
         }
 
         private void ResetToDefaults(object sender, EventArgs e)
@@ -346,7 +346,7 @@ namespace Mamesaver
 
             // Advanced
             _advancedSettings.DebugLogging = debugLogging.Checked;
-            _advancedSettings.SkipGameValidation = skipGameValidation.Checked;
+            _advancedSettings.IncludeImperfectEmulation = includeImperfectEmulation.Checked;
         }
 
         /**

--- a/Mamesaver/Configuration/Models/AdvancedSettings.cs
+++ b/Mamesaver/Configuration/Models/AdvancedSettings.cs
@@ -6,14 +6,14 @@ namespace Mamesaver.Configuration.Models
     public class AdvancedSettings
     {
         /// <summary>
-        ///     Disable status checks on MAME ROMs.
+        ///     Include games which have imperfect emulation.
         /// </summary>
         /// <remarks>
-        ///     This is usfeul if running a custom MAME build with the mandatory imperfect emulation
+        ///     This is useful if running a custom MAME build with the mandatory imperfect emulation
         ///     screen disabled.
         /// </remarks>
-        [XmlElement("SkipGameValidation")]
-        public bool SkipGameValidation { get; set; }
+        [XmlElement("IncludeImperfectEmulation")]
+        public bool IncludeImperfectEmulation { get; set; }
 
         /// <summary>
         ///     Enable debug logging to disk.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Other than those main settings, you can also:
 * Enable and configure the splash screen with game information
 * Enable and configure in-game game information
 * Enable multi-monitor cloning
-* Disable game validation
+* Include games with imperfect emulation
 
 ### COMMENTS
 
-* Game validation should only be bypassed for custom builds of MAME. Unless game validation has been skpped, the game list will only contain games which have passed the MAME ROM audit and have drivers with a status of good. This means that games, which might be partially working but maybe have no sound or some other part of the driver is not working, will not be displayed in this list. The main reason for this is that MAME shows a dialog which expects user input at the beginning of the game, which is the exact opposite of what you would want a screen saver to do.
+* Including games with imperfect emulation should only be enabled for custom builds of MAME. Unless this is enabled, the game list will only contain games which have passed the MAME ROM audit and have drivers with a status of good. This means that games, which might be partially working but maybe have no sound or some other part of the driver is not working, will not be displayed in this list. The main reason for this is that MAME shows a dialog which expects user input at the beginning of the game, which is the exact opposite of what you would want a screen saver to do.
 
 ### LOGGING
 


### PR DESCRIPTION
This PR renames the vague 'skip game validation' option with 'Include games with imperfect emulation' and tightens up the rules. The previous option skipped game status checks entirely with this enabled, however this inadvertently included BIOS ROMs and completely broken ROMs.

The behaviour now is for this option to include `imperfect` in addition to `good` for valid statuses.

The PR also tweaks the logging slightly. The previous behaviour was to only log to the event log if there isn't any filesystem logging, This has been changed to always write to the Windows Event Log for error and warning logging.