### PR TITLE
Explicit sleep management

### DIFF
--- a/Mamesaver.Test/Integration/PowerTests.cs
+++ b/Mamesaver.Test/Integration/PowerTests.cs
@@ -1,0 +1,20 @@
+﻿using Mamesaver.Windows;
+using NUnit.Framework;
+
+namespace Mamesaver.Test.Integration
+{
+    [TestFixture]
+    public class PowerTests
+    {
+        [Test]
+        [Description("Sanity check for retrieving power policy and type")]
+        public void GetPowerPolicy()
+        {
+            var powerType = PowerInterop.GetPowerType();
+            Assert.NotNull(powerType);
+
+            var policy = PowerInterop.GetPowerPolicy(powerType.Value);
+            Assert.NotNull(policy);
+        }
+    }
+}

--- a/Mamesaver.Test/Mamesaver.Test.csproj
+++ b/Mamesaver.Test/Mamesaver.Test.csproj
@@ -59,7 +59,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Integration\GameListStoreTest.cs" />
-    <Compile Include="Integration\HotKeyManagerTests.cs" />
+    <Compile Include="Integration\PowerTests.cs" />
+    <Compile Include="Unit\HotKeyManagerTests.cs" />
     <Compile Include="Integration\SettingsStoreTests.cs" />
     <Compile Include="Integration\TestActivityHook.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Mamesaver.Test/Unit/HotKeyManagerTests.cs
+++ b/Mamesaver.Test/Unit/HotKeyManagerTests.cs
@@ -4,14 +4,15 @@ using System.Windows.Forms;
 using FluentAssertions;
 using Mamesaver.Configuration.Models;
 using Mamesaver.Hotkeys;
-using Mamesaver.Test.Unit;
+using Mamesaver.Power;
+using Mamesaver.Test.Integration;
 using NUnit.Framework;
 
-namespace Mamesaver.Test.Integration
+namespace Mamesaver.Test.Unit
 {
     [TestFixture]
     [TestOf(typeof(HotKeyManager))]
-    public class HotKeyManagerTests : MamesaverTests
+    public class HotKeyManagerTests 
     {
         private HotKeyManager _manager;
         private TestActivityHook _activityHook;
@@ -20,10 +21,11 @@ namespace Mamesaver.Test.Integration
         public void SetUp()
         {
             _activityHook = new TestActivityHook();
-            _manager = new HotKeyManager(_activityHook, new Settings { HotKeys = true});
+
+            var powerManager = new PowerManager(new PowerEventWatcher());
+            _manager = new HotKeyManager(_activityHook, new Settings { HotKeys = true }, powerManager);
             _manager.Initialise();
         }
-
 
         public void UnhandledKeyManaged()
         {
@@ -73,7 +75,9 @@ namespace Mamesaver.Test.Integration
         [Description("Verifies that a hotkey is treated as unhandled if hotkeys are disabled")]
         public void HotKeyUnhandledIfHotKeysDisabled()
         {
-            var manager = new HotKeyManager(_activityHook, new Settings { HotKeys = false });
+            var powerManager = new PowerManager(new PowerEventWatcher());
+            var manager = new HotKeyManager(_activityHook, new Settings { HotKeys = false }, powerManager);
+            
             manager.Initialise();
 
             var hotKeyResetEvent = new AutoResetEvent(false);

--- a/Mamesaver/BlankScreen.cs
+++ b/Mamesaver/BlankScreen.cs
@@ -28,6 +28,16 @@ namespace Mamesaver
             Cursor.Hide();
         }
 
+        /// <summary>
+        ///     Hide the background form elements to provide seamless transition between games or after MAME termination.
+        /// </summary>
+        protected void HideBackgroundForm()
+        {
+            BackgroundForm.HideAll();
+
+            // Force an immediate refresh to avoid flicker of the MAME logo
+            BackgroundForm.Refresh();
+        }
         private void BackgroundForm_Load(object sender, EventArgs e)
         {
             WindowsInterop.SetWinFullScreen(BackgroundForm.Handle, Screen.Bounds.Left, Screen.Bounds.Top, Screen.Bounds.Width, Screen.Bounds.Height);
@@ -36,6 +46,8 @@ namespace Mamesaver
 
         private void ReleaseDeviceContext()
         {
+            HideBackgroundForm();
+
             try
             {
                 if (HandleDeviceContext == IntPtr.Zero)

--- a/Mamesaver/BlankScreenFactory.cs
+++ b/Mamesaver/BlankScreenFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Mamesaver.Configuration.Models;
+using Mamesaver.Power;
 
 namespace Mamesaver
 {
@@ -8,12 +9,17 @@ namespace Mamesaver
     internal class BlankScreenFactory
     {
         private readonly LayoutSettings _layoutSettings;
+        private readonly PowerManager _powerManager;
 
-        public BlankScreenFactory(LayoutSettings layoutSettings) => _layoutSettings = layoutSettings;
+        public BlankScreenFactory(LayoutSettings layoutSettings, PowerManager powerManager)
+        {
+            _layoutSettings = layoutSettings;
+            _powerManager = powerManager;
+        }
 
         /// <summary>
         ///     Creates a new <see cref="BlankScreen"/>.
         /// </summary>
-        public BlankScreen Create() => new BlankScreen(_layoutSettings);
+        public BlankScreen Create() => new BlankScreen(_layoutSettings, _powerManager);
     }
 }

--- a/Mamesaver/CaptureScreen.cs
+++ b/Mamesaver/CaptureScreen.cs
@@ -17,14 +17,14 @@ namespace Mamesaver
         public void Initialise(Rectangle sourceRect)
         {
             _sourceRect = sourceRect;
-            _sourceHwnd = PlatformInvokeUser32.GetDesktopWindow();
-            _hDeviceContext = PlatformInvokeUser32.GetDC(_sourceHwnd);
+            _sourceHwnd = GetDesktopWindow();
+            _hDeviceContext = GetDC(_sourceHwnd);
         }
 
         public void CloneTo(IntPtr destinationDeviceContext, Rectangle destinationRect)
         {
-            PlatformInvokeGdi32.StretchBlt(destinationDeviceContext, 0, 0, destinationRect.Width, destinationRect.Height,
-                _hDeviceContext, _sourceRect.X, _sourceRect.Y, _sourceRect.Width, _sourceRect.Height, PlatformInvokeGdi32.SRCOPY);
+            StretchBlt(destinationDeviceContext, 0, 0, destinationRect.Width, destinationRect.Height,
+                _hDeviceContext, _sourceRect.X, _sourceRect.Y, _sourceRect.Width, _sourceRect.Height, SRCOPY);
         }
 
         public void Dispose()

--- a/Mamesaver/CaptureScreen.cs
+++ b/Mamesaver/CaptureScreen.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Drawing;
-using Mamesaver.Windows;
 using Serilog;
+using static Mamesaver.Windows.PlatformInvokeUser32;
+using static Mamesaver.Windows.PlatformInvokeGdi32;
 
 namespace Mamesaver
 {
@@ -15,9 +16,9 @@ namespace Mamesaver
         private IntPtr _hBitmap = IntPtr.Zero;
 
         public CaptureScreen() : this(
-            PlatformInvokeUser32.GetDesktopWindow(),
-            PlatformInvokeUser32.GetSystemMetrics(PlatformInvokeUser32.SM_CXSCREEN),
-            PlatformInvokeUser32.GetSystemMetrics(PlatformInvokeUser32.SM_CYSCREEN))
+            GetDesktopWindow(),
+            GetSystemMetrics(SM_CXSCREEN),
+            GetSystemMetrics(SM_CYSCREEN))
         {
         }
 
@@ -27,16 +28,16 @@ namespace Mamesaver
             _width = width;
             _height = height;
 
-            _hDeviceContext = PlatformInvokeUser32.GetDC(_sourceHwnd);
+            _hDeviceContext = GetDC(_sourceHwnd);
         }
 
         public Bitmap Capture()
         {
-            if (_hMemoryContext == IntPtr.Zero) _hMemoryContext = PlatformInvokeGdi32.CreateCompatibleDC(_hDeviceContext);
-            if (_hBitmap == IntPtr.Zero) _hBitmap = PlatformInvokeGdi32.CreateCompatibleBitmap(_hDeviceContext, _width, _height);
+            if (_hMemoryContext == IntPtr.Zero) _hMemoryContext = CreateCompatibleDC(_hDeviceContext);
+            if (_hBitmap == IntPtr.Zero) _hBitmap = CreateCompatibleBitmap(_hDeviceContext, _width, _height);
 
-            PlatformInvokeGdi32.SelectObject(_hMemoryContext, _hBitmap);
-            PlatformInvokeGdi32.BitBlt(_hMemoryContext, 0, 0, _width, _height, _hDeviceContext, 0, 0, PlatformInvokeGdi32.SRCOPY);
+            SelectObject(_hMemoryContext, _hBitmap);
+            BitBlt(_hMemoryContext, 0, 0, _width, _height, _hDeviceContext, 0, 0, SRCOPY);
             var bitmap = Image.FromHbitmap(_hBitmap);
             return bitmap;
         }
@@ -45,8 +46,8 @@ namespace Mamesaver
         {
             Log.Verbose("Cloning screen {width}x{height} to {destination}", _width, _height, destinationRect);
 
-            PlatformInvokeGdi32.StretchBlt(destinationDeviceContext, 0, 0, destinationRect.Width, destinationRect.Height,
-                _hDeviceContext, 0, 0, _width, _height, PlatformInvokeGdi32.SRCOPY);
+            StretchBlt(destinationDeviceContext, 0, 0, destinationRect.Width, destinationRect.Height,
+                _hDeviceContext, 0, 0, _width, _height, SRCOPY);
         }
 
         public void Dispose()
@@ -64,19 +65,19 @@ namespace Mamesaver
             {
                 if (_hBitmap != IntPtr.Zero)
                 {
-                    PlatformInvokeGdi32.DeleteObject(_hBitmap);
+                    DeleteObject(_hBitmap);
                     _hBitmap = IntPtr.Zero;
                 }
 
                 if (_hMemoryContext != IntPtr.Zero)
                 {
-                    PlatformInvokeGdi32.DeleteDC(_hMemoryContext);
+                    DeleteDC(_hMemoryContext);
                     _hMemoryContext = IntPtr.Zero;
                 }
 
                 if (_hDeviceContext != IntPtr.Zero)
                 {
-                    PlatformInvokeUser32.ReleaseDC(_sourceHwnd, _hDeviceContext);
+                    ReleaseDC(_sourceHwnd, _hDeviceContext);
                     _hDeviceContext = IntPtr.Zero;
                 }
             }

--- a/Mamesaver/ContainerFactory.cs
+++ b/Mamesaver/ContainerFactory.cs
@@ -2,6 +2,7 @@ using Mamesaver.Configuration;
 using Mamesaver.Configuration.Models;
 using Mamesaver.Hotkeys;
 using Mamesaver.Layout;
+using Mamesaver.Power;
 using Mamesaver.Windows;
 using SimpleInjector;
 using SimpleInjector.Lifestyles;
@@ -37,13 +38,15 @@ namespace Mamesaver
             container.Register<CaptureScreen>(Lifestyle.Scoped);
             container.Register<ScreenCloner>(Lifestyle.Scoped);
             container.Register<ScreenManager>(Lifestyle.Scoped);
+            container.Register<PowerManager>(Lifestyle.Scoped);
+            container.Register<HotKeyManager>(Lifestyle.Scoped);
 
             container.Register<GameListBuilder>(Lifestyle.Singleton);
             container.Register<TitleFactory>(Lifestyle.Singleton);
             container.Register<LayoutBuilder>(Lifestyle.Singleton);
             container.Register<LayoutFactory>(Lifestyle.Singleton);
             container.Register<MameInvoker>(Lifestyle.Singleton);
-            container.Register<HotKeyManager>(Lifestyle.Singleton);
+            container.Register<PowerEventWatcher>(Lifestyle.Singleton);
 
             container.Register<IActivityHook>(() => new UserActivityHook(), Lifestyle.Singleton);
 

--- a/Mamesaver/Hotkeys/HotKeyManager.cs
+++ b/Mamesaver/Hotkeys/HotKeyManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Windows.Forms;
 using Mamesaver.Configuration.Models;
+using Mamesaver.Power;
 using Mamesaver.Windows;
 using Serilog;
 
@@ -32,14 +33,20 @@ namespace Mamesaver.Hotkeys
 
         private readonly IActivityHook _activityHook;
         private readonly Settings _settings;
+        private readonly PowerManager _powerManager;
 
-        public HotKeyManager(IActivityHook activityHook, Settings settings)
+        public HotKeyManager(IActivityHook activityHook, Settings settings, PowerManager powerManager)
         {
             _activityHook = activityHook;
             _settings = settings;
+            _powerManager = powerManager;
         }
 
-        public void Initialise() => _activityHook.KeyDown += OnKeyDown;
+        public void Initialise()
+        {
+            Log.Debug("Initialising hotkey manager");
+            _activityHook.KeyDown += OnKeyDown;
+        }
 
         /// <summary>
         ///     Handles key down events, dispatching events for both hotkeys and unhandled key presses.
@@ -47,6 +54,9 @@ namespace Mamesaver.Hotkeys
         private void OnKeyDown(object sender, KeyEventArgs e)
         {
             var key = e.KeyCode;
+
+            // Reset display sleep timer
+            _powerManager.ResetTimer();
 
             if (_settings.HotKeys && _keyMapping.ContainsKey(key))
             {

--- a/Mamesaver/MameInvoker.cs
+++ b/Mamesaver/MameInvoker.cs
@@ -42,7 +42,6 @@ namespace Mamesaver
             }
             catch (Exception e)
             {
-
                 Log.Error(e, "Error stopping MAME");
             }
         }

--- a/Mamesaver/MameScreen.cs
+++ b/Mamesaver/MameScreen.cs
@@ -136,10 +136,7 @@ namespace Mamesaver
                     // Unsubscribe from hotkey events as control is being handed over to MAME
                     _hotKeyManager.HotKeyPressed -= ProcessHotKey;
 
-                    // Hide the background form elements to provide a seamless transition. We are also
-                    // forcing an immediate refresh to avoid any flicker of the MAME logo before it's hidden.
-                    BackgroundForm.HideAll();
-                    BackgroundForm.Refresh();
+                   HideBackgroundForm();
 
                     _gameTimer.Stop();
 
@@ -283,8 +280,7 @@ namespace Mamesaver
                 _splashTimer?.Stop();
                 _gameTimer = _splashTimer = null;
 
-                BackgroundForm.HideAll();
-                BackgroundForm.Refresh();
+                HideBackgroundForm();
 
                 // Stop MAME and wait for it to terminate
                 _invoker.Stop(GameProcess);

--- a/Mamesaver/MameScreen.cs
+++ b/Mamesaver/MameScreen.cs
@@ -7,6 +7,7 @@ using Mamesaver.Configuration;
 using Mamesaver.Configuration.Models;
 using Mamesaver.Hotkeys;
 using Mamesaver.Layout;
+using Mamesaver.Power;
 using Serilog;
 using LayoutSettings = Mamesaver.Configuration.Models.LayoutSettings;
 
@@ -23,6 +24,7 @@ namespace Mamesaver
         private readonly GameListStore _gameListStore;
         private readonly HotKeyManager _hotKeyManager;
         private readonly LayoutBuilder _layoutBuilder;
+        private readonly PowerManager _powerManager;
         private readonly MameInvoker _invoker;
         private readonly SplashScreen _splashSettings;
 
@@ -61,13 +63,15 @@ namespace Mamesaver
             GameListStore gameListStore,
             HotKeyManager hotKeyManager,
             LayoutBuilder layoutBuilder,
-            MameInvoker invoker) : base(layoutSettings)
+            PowerManager powerManager,
+            MameInvoker invoker) : base(layoutSettings, powerManager)
         {
             _settings = settings;
             _gameList = gameList;
             _gameListStore = gameListStore;
             _hotKeyManager = hotKeyManager;
             _layoutBuilder = layoutBuilder;
+            _powerManager = powerManager;
             _invoker = invoker;
 
             _splashSettings = layoutSettings.SplashScreen;
@@ -79,6 +83,7 @@ namespace Mamesaver
 
             _selectedGames = _gameList.SelectedGames.OrderBy(_ => _random.Next()).ToList();
             _hotKeyManager.HotKeyPressed += ProcessHotKey;
+            _powerManager.SleepTriggered += OnSleep;
 
             BackgroundForm.mameLogo.Visible = true;
             BackgroundForm.Load += OnFormBackground_Load;
@@ -89,6 +94,20 @@ namespace Mamesaver
             _initialised = true;
 
             Log.Information("Initialised primary MAME screen");
+        }
+
+        /// <summary>
+        ///     Handles sleep events, closing MAME.
+        /// </summary>
+        private void OnSleep(object sender, EventArgs args)
+        {
+            Log.Information("Stopping MAME due to sleep event");
+
+            _powerManager.SleepTriggered -= OnSleep;
+            DisposeTimers();
+            HideBackgroundForm();
+
+            _invoker.Stop(GameProcess);
         }
 
         /// <summary>
@@ -276,10 +295,7 @@ namespace Mamesaver
 
             try
             {
-                _gameTimer?.Stop();
-                _splashTimer?.Stop();
-                _gameTimer = _splashTimer = null;
-
+                DisposeTimers();
                 HideBackgroundForm();
 
                 // Stop MAME and wait for it to terminate
@@ -289,6 +305,13 @@ namespace Mamesaver
             {
                 Log.Error(ex, "Error closing screen");
             }
+        }
+
+        private void DisposeTimers()
+        {
+            _gameTimer?.Stop();
+            _splashTimer?.Stop();
+            _gameTimer = _splashTimer = null;
         }
 
         public void Dispose()

--- a/Mamesaver/Mamesaver.cs
+++ b/Mamesaver/Mamesaver.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Windows.Forms;
 using Mamesaver.Configuration.Models;
 using Mamesaver.Hotkeys;
+using Mamesaver.Power;
 using Serilog;
 
 namespace Mamesaver
@@ -18,6 +19,7 @@ namespace Mamesaver
         private readonly ScreenCloner _screenCloner;
         private readonly ScreenManager _screenManager;
         private readonly HotKeyManager _hotKeyManager;
+        private readonly PowerManager _powerManager;
         private readonly Settings _settings;
         private readonly GameList _gameList;
         private readonly BlankScreenFactory _screenFactory;
@@ -30,6 +32,7 @@ namespace Mamesaver
             ScreenCloner screenCloner,
             ScreenManager screenManager,
             HotKeyManager hotKeyManager,
+            PowerManager powerManager,
             BlankScreenFactory screenFactory,
             MameInvoker invoker,
             MameScreen mameScreen)
@@ -39,6 +42,7 @@ namespace Mamesaver
             _screenCloner = screenCloner;
             _screenManager = screenManager;
             _hotKeyManager = hotKeyManager;
+            _powerManager = powerManager;
             _screenFactory = screenFactory;
             _invoker = invoker;
             _mameScreen = mameScreen;
@@ -58,8 +62,12 @@ namespace Mamesaver
                     return;
                 }
 
+                // Start listening for user input events
                 _screenManager.Initialise();
                 _hotKeyManager.Initialise();            
+
+                // Start power management timer
+                _powerManager.Initialise();
 
                 // Verify that MAME can be run so we can return immediately if there are errors
                 _invoker.Run("-showconfig");

--- a/Mamesaver/Mamesaver.csproj
+++ b/Mamesaver/Mamesaver.csproj
@@ -67,6 +67,7 @@
     <Reference Include="System.configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
@@ -97,6 +98,8 @@
     <Compile Include="Configuration\Models\SplashScreen.cs" />
     <Compile Include="Configuration\GameListStore.cs" />
     <Compile Include="MultiFormApplicationContext.cs" />
+    <Compile Include="Power\PowerEventWatcher.cs" />
+    <Compile Include="Power\PowerManager.cs" />
     <Compile Include="ScreenCloner.cs" />
     <Compile Include="ConfigForm.cs">
       <SubType>Form</SubType>
@@ -122,8 +125,7 @@
     <Compile Include="Configuration\GeneralSettingsStore.cs" />
     <Compile Include="Configuration\SettingsStore.cs" />
     <Compile Include="ScreenManager.cs" />
-    <Compile Include="Windows\PlatformInvokeGDI32.cs" />
-    <Compile Include="Windows\PlatformInvokeUSER32.cs" />
+    <Compile Include="Windows\MonitorInterop.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Mamesaver.cs">
@@ -135,6 +137,11 @@
     </Compile>
     <Compile Include="SelectableGame.cs" />
     <Compile Include="Configuration\Models\Settings.cs" />
+    <Compile Include="Windows\PlatformInvokeGdi32.cs" />
+    <Compile Include="Windows\PlatformInvokePowrprof.cs" />
+    <Compile Include="Windows\PlatformInvokeKernel32.cs" />
+    <Compile Include="Windows\PlatformInvokeUser32.cs" />
+    <Compile Include="Windows\PowerInterop.cs" />
     <Compile Include="Windows\UserActivityHook.cs" />
     <Compile Include="Windows\WindowsInterop.cs" />
   </ItemGroup>

--- a/Mamesaver/Power/PowerEventWatcher.cs
+++ b/Mamesaver/Power/PowerEventWatcher.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Management;
+using Serilog;
+
+namespace Mamesaver.Power
+{
+    /// <summary>
+    ///     Listens for power source change events, firing a <see cref="PowerStateChanged"/> event
+    ///     if received.
+    /// </summary>
+    public class PowerEventWatcher
+    {
+        /// <summary>
+        ///     Value of event corresponding to a power state change.
+        /// </summary>
+        private const ushort PowerStateChange = 10;
+
+        private const string ManagementPath = "root\\CIMV2";
+        private const string EventClass = "Win32_PowerManagementEvent";
+
+        private ManagementEventWatcher _managementEventWatcher;
+        public event PowerEventHandler PowerStateChanged;
+
+        public delegate void PowerEventHandler(object sender, EventArgs args);
+
+        /// <summary>
+        ///     Initialises the power event watcher to fire <see cref="PowerStateChanged"/>
+        ///     events on power source change.
+        /// </summary>
+        public void Initialise()
+        {
+            Log.Debug("Initialising power event watcher");
+
+            var query = new WqlEventQuery { EventClassName = EventClass };
+            var scope = new ManagementScope(ManagementPath);
+
+            _managementEventWatcher = new ManagementEventWatcher(scope, query);
+            _managementEventWatcher.EventArrived += PowerEventArrived;
+            _managementEventWatcher.Start();
+        }
+
+        /// <summary>
+        ///     Invoked when a power event has been received.
+        /// </summary>
+        private void PowerEventArrived(object sender, EventArrivedEventArgs args)
+        {
+            foreach (var propertyData in args.NewEvent.Properties)
+            {
+                var id = propertyData?.Value as ushort?;
+                if (id == PowerStateChange) PowerStateChanged?.Invoke(this, new EventArgs());
+            }
+        }
+
+        public virtual void Dispose(bool disposing)
+        {
+            if (!disposing) return;
+
+            _managementEventWatcher?.Stop();
+            _managementEventWatcher?.Dispose();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~PowerEventWatcher() => Dispose(false);
+    }
+}

--- a/Mamesaver/Power/PowerManager.cs
+++ b/Mamesaver/Power/PowerManager.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Linq;
+using System.Timers;
+using Mamesaver.Windows;
+using Serilog;
+
+namespace Mamesaver.Power
+{
+    /// <summary>
+    ///     Identifies screen and PC power management configuration, firing a single <see cref="SleepTriggered"/> event 
+    ///     when the either require sleeping. This explicit power management is required because MAME prevents both 
+    ///     the display and the PC from going to sleep.
+    /// </summary>
+    /// <remarks>
+    ///     Currently, the <see cref="SleepTriggered"/> event doesn't differentiate between screen and PC power 
+    ///     saving, nor does it contain any information about the requested action for PC power management. It is
+    ///     expected that either will only be used to turn the screen off and terminate MAME.
+    /// </remarks>
+    public class PowerManager : IDisposable
+    {
+        private readonly PowerEventWatcher _eventWatcher;
+        private Timer _sleepTimer;
+
+        public delegate void SleepTriggerManager(object sender, EventArgs args);
+
+        /// <summary>
+        ///     Fired when the screensaver should turn the display to sleep.
+        /// </summary>
+        public event SleepTriggerManager SleepTriggered;
+
+        /// <summary>
+        ///     Time before a <see cref="SleepTriggered"/> event is published, based on the user's power management 
+        ///     configuration.
+        /// </summary>
+        private TimeSpan _sleepTimeout;
+
+        /// <summary>
+        ///     Current power source type.
+        /// </summary>
+        private PowerType _currentPowerType;
+
+        public PowerManager(PowerEventWatcher eventWatcher) => _eventWatcher = eventWatcher;
+
+        /// <summary>
+        ///     Resets the sleep timer.
+        /// </summary>
+        public void ResetTimer()
+        {
+            if (_sleepTimer == null) return;
+
+            Log.Debug("Resetting sleep timer");
+            _sleepTimer.Stop();
+            _sleepTimer.Start();
+        }
+
+        /// <summary>
+        ///     Initialises the power manager to publish <see cref="PowerStateChanged"/> events when power state
+        ///     has changed from AC to DC or vice versa.
+        /// </summary>
+        public void Initialise()
+        {
+            Log.Debug("Initialising power manager");
+
+            // Identify whether we are on AC or DC power
+            if (!GetPowerType(out var powerType) || powerType == null)
+            {
+                Log.Warning("Unable to determine power source; unable to perform power management");
+                return;
+            }
+
+            _currentPowerType = powerType.Value;
+
+            // Identify policy for selected power type
+            _sleepTimeout = GetSleepTimeout(powerType.Value);
+            Log.Information("Connected to {powerType} power; sleeping after {min} minutes", 
+                powerType.Value.ToString(), _sleepTimeout.TotalMinutes);
+
+            // Create a timer which fires once when the display or computer should go to sleep
+            _sleepTimer = new Timer { Interval = (int)_sleepTimeout.TotalMilliseconds, AutoReset = false };
+
+            _sleepTimer.Elapsed += SleepTimerTick;
+            _sleepTimer.Start();
+
+            // Receive notifications for power state changes so the timer can be updated
+            _eventWatcher.Initialise();
+            _eventWatcher.PowerStateChanged += PowerStateChanged;
+        }
+
+        /// <summary>
+        ///     Returns the lowest of screen and PC sleep settings for a given power type.
+        /// </summary>
+        private static TimeSpan GetSleepTimeout(PowerType powerType)
+        {
+            var powerPolicy = PowerInterop.GetPowerPolicy(powerType);
+            return new[] { powerPolicy.VideoTimeout, powerPolicy.IdleTimeout }.Min();
+        }
+
+        /// <summary>
+        ///     Retrieves the current power source.
+        /// </summary>
+        private static bool GetPowerType(out PowerType? powerType)
+        {
+            powerType = PowerInterop.GetPowerType();
+            return powerType != null;
+       }
+
+        /// <summary>
+        ///     Invoked when the power state has changed from AC to DC or vice versa.
+        /// </summary>
+        private void PowerStateChanged(object sender, EventArgs args)
+        {
+            if (!GetPowerType(out var powerType) || powerType == null)
+            {
+                Log.Warning("Unable to determine power source; not reacting to power state change");
+                return;
+            }
+
+            // Multiple identical state change events can be triggered; return if there's nothing to do
+            if (_currentPowerType == powerType) return;
+            _currentPowerType = powerType.Value;
+
+            // Identify policy for selected power type
+            _sleepTimeout = GetSleepTimeout(powerType.Value);
+            Log.Information("Power changed to {powerType} power; sleeping after {min} minutes",
+                powerType.Value.ToString(), _sleepTimeout.TotalMinutes);
+
+            // Update sleep timer on power state change due to different sleep configurations
+            _sleepTimer.Interval = (int)_sleepTimeout.TotalMilliseconds;
+
+            _sleepTimer.Stop();
+            _sleepTimer.Start();
+        }
+
+        /// <summary>
+        ///     Publishes a <see cref="SleepTriggered"/> event when either the display or PC require sleeping.
+        /// </summary>
+        private void SleepTimerTick(object sender, EventArgs e) => SleepTriggered?.Invoke(this, new EventArgs());
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public virtual void Dispose(bool disposing)
+        {
+            if (!disposing) return;
+            _sleepTimer?.Dispose();
+        }
+
+        ~PowerManager() => Dispose(false);
+    }
+}

--- a/Mamesaver/Windows/MonitorInterop.cs
+++ b/Mamesaver/Windows/MonitorInterop.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+using static Mamesaver.Windows.PlatformInvokeUser32;
+
+// ReSharper disable InconsistentNaming
+namespace Mamesaver.Windows
+{
+    public static class MonitorInterop
+    {
+        private const int WM_SYSCOMMAND = 0x112;
+        private const int SC_MONITORPOWER = 0xF170;
+
+        public static void SetMonitorState(IntPtr handle, MonitorState state)
+        {
+            SendMessage(handle, WM_SYSCOMMAND, SC_MONITORPOWER, new IntPtr((int)state));
+        }
+    }
+
+    public enum MonitorState
+    {
+        MonitorStateOn = -1,
+        MonitorStateOff = 2,
+        MonitorStateStandBy = 1
+    }
+}

--- a/Mamesaver/Windows/PlatformInvokeKernel32.cs
+++ b/Mamesaver/Windows/PlatformInvokeKernel32.cs
@@ -1,0 +1,34 @@
+﻿using System.Runtime.InteropServices;
+// ReSharper disable InconsistentNaming
+
+namespace Mamesaver.Windows
+{
+    internal static class PlatformInvokeKernel32
+    {
+        [DllImport("Kernel32", EntryPoint = "GetSystemPowerStatus")]
+        public static extern bool GetSystemPowerStatusRef(SYSTEM_POWER_STATUS sps);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class SYSTEM_POWER_STATUS
+    {
+        public ACLineStatus ACLineStatus;
+        public BatteryFlag BatteryFlag;
+        public byte BatteryLifePercent;
+        public byte Reserved1;
+        public int BatteryLifeTime;
+        public int BatteryFullLifeTime;
+    }
+
+    // Note: Underlying type of byte to match Win32 header
+    public enum ACLineStatus : byte
+    {
+        Offline = 0, Online = 1, Unknown = 255
+    }
+
+    public enum BatteryFlag : byte
+    {
+        High = 1, Low = 2, Critical = 4, Charging = 8,
+        NoSystemBattery = 128, Unknown = 255
+    }
+}

--- a/Mamesaver/Windows/PlatformInvokePowrprof.cs
+++ b/Mamesaver/Windows/PlatformInvokePowrprof.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+// ReSharper disable InconsistentNaming
+namespace Mamesaver.Windows
+{
+    /// <summary>
+    ///     Windows Power Management Configuration Tools invoker.
+    /// </summary>
+    internal class PlatformInvokerPowrprof
+    {
+        [DllImport("powrprof.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool GetCurrentPowerPolicies(ref GLOBAL_POWER_POLICY pGlobalPowerPolicy, ref POWER_POLICY pPowerPolicy);
+    }
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct GLOBAL_POWER_POLICY
+    {
+        public GLOBAL_USER_POWER_POLICY UserPolicy;
+        public GLOBAL_MACHINE_POWER_POLICY MachinePolicy;
+    }
+
+    [Flags]
+    enum GlobalPowerPolicyFlags : uint
+    {
+        EnableSysTrayBatteryMeter = 0x01,
+        EnableMultiBatteryDisplay = 0x02,
+        EnablePasswordAtLogon = 0x04,
+        EnableWakeOnRing = 0x08,
+        EnableVideoDimDisplay = 0x10,
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct GLOBAL_USER_POWER_POLICY
+    {
+        public const int NUM_DISCHARGE_POLICIES = 4;
+
+        public uint Revision;
+        public POWER_ACTION_POLICY PowerButtonAc;
+        public POWER_ACTION_POLICY PowerButtonDc;
+        public POWER_ACTION_POLICY SleepButtonAc;
+        public POWER_ACTION_POLICY SleepButtonDc;
+        public POWER_ACTION_POLICY LidCloseAc;
+        public POWER_ACTION_POLICY LidCloseDc;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = NUM_DISCHARGE_POLICIES)]
+        public SYSTEM_POWER_LEVEL[] DischargePolicy;
+        public GlobalPowerPolicyFlags GlobalFlags;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct GLOBAL_MACHINE_POWER_POLICY
+    {
+        public uint Revision;
+        public SYSTEM_POWER_STATE LidOpenWakeAc;
+        public SYSTEM_POWER_STATE LidOpenWakeDc;
+        public uint BroadcastCapacityResolution;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct SYSTEM_POWER_LEVEL
+    {
+        public bool Enable;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
+        public byte[] Spare;
+        public uint BatteryLevel;
+        public POWER_ACTION_POLICY PowerPolicy;
+        public SYSTEM_POWER_STATE MinSystemState;
+    }
+
+    enum SYSTEM_POWER_STATE
+    {
+        PowerSystemUnspecified = 0,
+        PowerSystemWorking = 1,
+        PowerSystemSleeping1 = 2,
+        PowerSystemSleeping2 = 3,
+        PowerSystemSleeping3 = 4,
+        PowerSystemHibernate = 5,
+        PowerSystemShutdown = 6,
+        PowerSystemMaximum = 7
+    }
+
+    enum POWER_ACTION : uint
+    {
+        PowerActionNone = 0,       // No system power action. 
+        PowerActionReserved,       // Reserved; do not use. 
+        PowerActionSleep,      // Sleep. 
+        PowerActionHibernate,      // Hibernate. 
+        PowerActionShutdown,       // Shutdown. 
+        PowerActionShutdownReset,  // Shutdown and reset. 
+        PowerActionShutdownOff,    // Shutdown and power off. 
+        PowerActionWarmEject,      // Warm eject.
+    }
+
+    [Flags]
+    enum PowerActionFlags : uint
+    {
+        POWER_ACTION_QUERY_ALLOWED = 0x00000001, // Broadcasts a PBT_APMQUERYSUSPEND event to each application to request permission to suspend operation.
+        POWER_ACTION_UI_ALLOWED = 0x00000002, // Applications can prompt the user for directions on how to prepare for suspension. Sets bit 0 in the Flags parameter passed in the lParam parameter of WM_POWERBROADCAST.
+        POWER_ACTION_OVERRIDE_APPS = 0x00000004, // Ignores applications that do not respond to the PBT_APMQUERYSUSPEND event broadcast in the WM_POWERBROADCAST message.
+        POWER_ACTION_LIGHTEST_FIRST = 0x10000000, // Uses the first lightest available sleep state.
+        POWER_ACTION_LOCK_CONSOLE = 0x20000000, // Requires entry of the system password upon resume from one of the system standby states.
+        POWER_ACTION_DISABLE_WAKES = 0x40000000, // Disables all wake events.
+        POWER_ACTION_CRITICAL = 0x80000000, // Forces a critical suspension.
+    }
+
+    [Flags]
+    enum PowerActionEventCode : uint
+    {
+        POWER_LEVEL_USER_NOTIFY_TEXT = 0x00000001, // User notified using the UI. 
+        POWER_LEVEL_USER_NOTIFY_SOUND = 0x00000002, // User notified using sound. 
+        POWER_LEVEL_USER_NOTIFY_EXEC = 0x00000004, // Specifies a program to be executed. 
+        POWER_USER_NOTIFY_BUTTON = 0x00000008, // Indicates that the power action is in response to a user power button press. 
+        POWER_USER_NOTIFY_SHUTDOWN = 0x00000010, // Indicates a power action of shutdown/off.
+        POWER_FORCE_TRIGGER_RESET = 0x80000000, // Clears a user power button press. 
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct POWER_ACTION_POLICY
+    {
+        public POWER_ACTION Action;
+        public PowerActionFlags Flags;
+        public PowerActionEventCode EventCode;
+    }
+
+    struct POWER_POLICY
+    {
+        internal USER_POWER_POLICY user;
+        MACHINE_POWER_POLICY mach;
+    }
+
+    struct MACHINE_POWER_POLICY
+    {
+        uint Revision;
+        SYSTEM_POWER_STATE MinSleepAc;
+        SYSTEM_POWER_STATE MinSleepDc;
+        SYSTEM_POWER_STATE ReducedLatencySleepAc;
+        SYSTEM_POWER_STATE ReducedLatencySleepDc;
+        uint DozeTimeoutAc;
+        uint DozeTimeoutDc;
+        uint DozeS4TimeoutAc;
+        uint DozeS4TimeoutDc;
+        byte MinThrottleAc;
+        byte MinThrottleDc;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
+        byte[] pad1;
+        POWER_ACTION_POLICY OverThrottledAc;
+        POWER_ACTION_POLICY OverThrottledDc;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    struct USER_POWER_POLICY
+    {
+        public uint Revision;
+        public POWER_ACTION_POLICY IdleAc;
+        public POWER_ACTION_POLICY IdleDc;
+        public uint IdleTimeoutAc;
+        public uint IdleTimeoutDc;
+        public byte IdleSensitivityAc;
+        public byte IdleSensitivityDc;
+        public byte ThrottlePolicyAc;
+        public byte ThrottlePolicyDc;
+        public SYSTEM_POWER_STATE MaxSleepAc;
+        public SYSTEM_POWER_STATE MaxSleepDc;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
+        public uint[] Reserved;
+        public uint VideoTimeoutAc;
+        public uint VideoTimeoutDc;
+        public uint SpindownTimeoutAc;
+        public uint SpindownTimeoutDc;
+        [MarshalAs(UnmanagedType.I1)]
+        public bool OptimizeForPowerAc;
+        [MarshalAs(UnmanagedType.I1)]
+        public bool OptimizeForPowerDc;
+        public byte FanThrottleToleranceAc;
+        public byte FanThrottleToleranceDc;
+        public byte ForcedThrottleAc;
+        public byte ForcedThrottleDc;
+    }
+}

--- a/Mamesaver/Windows/PlatformInvokeUSER32.cs
+++ b/Mamesaver/Windows/PlatformInvokeUSER32.cs
@@ -10,6 +10,9 @@ namespace Mamesaver.Windows
         public const int SM_CYSCREEN = 1;
         public const int SW_MINIMIZE = 6;
 
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern IntPtr SendMessage(IntPtr hWnd, int Msg, int wParam, IntPtr lParam);
+
         [DllImport("user32.dll")]
         public static extern void SetWindowPos(IntPtr hwnd, IntPtr hwndInsertAfter, int x, int y, int width, int height, uint flags);
 

--- a/Mamesaver/Windows/PowerInterop.cs
+++ b/Mamesaver/Windows/PowerInterop.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Serilog;
+
+namespace Mamesaver.Windows
+{
+    public static class PowerInterop
+    {
+        public static PowerType? GetPowerType()
+        {
+            var powerState = new SYSTEM_POWER_STATUS();
+            if (!PlatformInvokeKernel32.GetSystemPowerStatusRef(powerState))
+            {
+                Log.Warning("Unable to get power state");
+                return null;
+            }
+
+            return powerState.ACLineStatus == ACLineStatus.Online ? PowerType.AC : PowerType.DC;
+        }
+
+        public static PowerPolicy GetPowerPolicy(PowerType powerType)
+        {
+            var powerPolicy = new POWER_POLICY();
+            var globalPowerPolicy = new GLOBAL_POWER_POLICY();
+
+            if (!PlatformInvokerPowrprof.GetCurrentPowerPolicies(ref globalPowerPolicy, ref powerPolicy))
+            {
+                Log.Warning("Unable to get power management state");
+                return null;
+            }
+
+            var userPolicy = powerPolicy.user;
+
+            switch (powerType)
+            {
+                case PowerType.AC:
+                    return new PowerPolicy
+                    {
+                        IdleTimeout =
+                            userPolicy.IdleTimeoutAc == 0 || userPolicy.IdleAc.Action == POWER_ACTION.PowerActionNone
+                                ? TimeSpan.MaxValue
+                                : TimeSpan.FromSeconds(userPolicy.IdleTimeoutAc),
+                        VideoTimeout = userPolicy.VideoTimeoutAc == 0
+                            ? TimeSpan.MaxValue
+                            : TimeSpan.FromSeconds(userPolicy.VideoTimeoutAc)
+                    };
+                case PowerType.DC:
+                    return new PowerPolicy
+                    {
+                        IdleTimeout =
+                            userPolicy.IdleTimeoutDc == 0 || userPolicy.IdleDc.Action == POWER_ACTION.PowerActionNone
+                                ? TimeSpan.MaxValue
+                                : TimeSpan.FromSeconds(userPolicy.IdleTimeoutDc),
+                        VideoTimeout = userPolicy.VideoTimeoutDc == 0
+                            ? TimeSpan.MaxValue
+                            : TimeSpan.FromSeconds(userPolicy.VideoTimeoutDc)
+                    };
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(powerType));
+            }
+        }
+    }
+
+    public enum PowerType
+    {
+        AC,
+        DC
+    }
+
+    public class PowerPolicy
+    {
+        public TimeSpan VideoTimeout { get; set; }
+        public TimeSpan IdleTimeout { get; set; }
+    }
+}


### PR DESCRIPTION
This PR implements explicit sleep management, as per #23.

Sleep management is required because MAME ignores both screen and PC sleep settings. With this PR, the user's screens are turned off and MAME stopped based on the user's sleep settings. This makes Mamesaver a better citizen, is more environmentally friendly, and stops unnecessarily and constantly high CPU usage if the screensaver is left on overnight.

This change:

1. Reads the user's preferences for putting the screen and PC to sleep
2. Identifies the current power source
3. Listens for power source change events
4. Stops MAME and sleeps monitors when either screen or PC sleep times are reached

Note that no power actions other than sleeping screens is performed (i.e., we are treating requests to hibernate etc. as if it was a screen sleep event).