### PR TITLE
Bug fixes for game list parsing

### DIFF
--- a/Mamesaver.Test/Integration/GameListStoreTests.cs
+++ b/Mamesaver.Test/Integration/GameListStoreTests.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 namespace Mamesaver.Test.Integration
 {
     [TestFixture]
-    public class GameListStoreTest : MamesaverTests
+    public class GameListStoreTests : MamesaverTests
     {
         private TestGameListStore _store;
 

--- a/Mamesaver.Test/Integration/MamePathManagerTests.cs
+++ b/Mamesaver.Test/Integration/MamePathManagerTests.cs
@@ -1,0 +1,112 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using Mamesaver.Configuration.Models;
+using Mamesaver.Test.Unit;
+using NUnit.Framework;
+
+namespace Mamesaver.Test.Integration
+{
+    [TestFixture]
+    [TestOf(typeof(MamePathManager))]
+    public class MamePathManagerTests : MamesaverTests
+    {
+        private MamePathManager _manager;
+        private string _mamePath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            
+            _manager = GetInstance<MamePathManager>();
+
+            var settings = GetInstance<Settings>();
+            _mamePath = Directory.GetParent(settings.ExecutablePath).ToString();
+        }
+
+        [Test]
+        public void NotMatchingConfigLine()
+        {
+            _manager.ExtractConfigPaths("rompath", "bananas foo bar").Should().BeNull();
+        }
+
+        [Test]
+        public void MatchingConfigLine()
+        {
+            var directories = _manager.ExtractConfigPaths("rompath", "rompath roms");
+            directories.Should().BeEquivalentTo(new List<string> { Path.Combine(_mamePath, "roms") });
+        }
+
+        [TestCase("rompath vector;shmups")]
+        [TestCase("rompath vector;  shmups")]
+        [TestCase("rompath          vector;shmups")]
+        [Description("Verifies extraction of multiple paths")]
+        public void MatchingConfigLineMultiplePaths(string line)
+        {
+            var directories = _manager.ExtractConfigPaths("rompath", line);
+            directories.Should().BeEquivalentTo(new List<string>
+            {
+                Path.Combine(_mamePath, "vector"),
+                Path.Combine(_mamePath, "shmups")
+            });
+        }
+
+        [Test]
+        [Description("Verifies that absolute paths are unchanged")]
+        public void MatchingConfigLineMixedAbsoluteRelative()
+        {
+            var directories = _manager.ExtractConfigPaths("rompath", @"rompath vector;c:\roms\shmups");
+            directories.Should().BeEquivalentTo(new List<string>
+            {
+                Path.Combine(_mamePath, "vector"),
+                @"c:\roms\shmups"
+            });
+        }
+
+        [Test]
+        [Description("Verifies that absolute paths are unchanged")]
+        public void MatchingConfigLineAbsolutePaths()
+        {
+           var directories = _manager.ExtractConfigPaths("rompath", @"rompath c:\roms\vector;c:\roms\shmups");
+            directories.Should().BeEquivalentTo(new List<string>
+            {
+                @"c:\roms\vector",
+                @"c:\roms\shmups"
+            });
+        } 
+
+        [Test]
+        [Description("Verifies that enclosing speech marks are removed from directory paths")]
+        public void MatchingConfigLineWithQuotes()
+        {
+            var directories = _manager.ExtractConfigPaths("rompath", @"rompath ""shmups and things""");
+            directories.Should().BeEquivalentTo(new List<string>
+            {
+                Path.Combine(_mamePath, "shmups and things")
+            });
+        }
+
+        [Test]
+        public void MatchingSinglePathWithQuotes()
+        {
+            var directories = _manager.ExtractConfigPaths("rompath", @"rompath vector;""shmups and things""");
+            directories.Should().BeEquivalentTo(new List<string>
+            {
+                Path.Combine(_mamePath, "vector"),
+                Path.Combine(_mamePath, "shmups and things")
+            });
+        }
+
+        [Test]
+        public void MatchingConfigLineMultiplePathsWithQuotes()
+        {
+            var directories = _manager.ExtractConfigPaths("rompath", @"rompath ""vector;shmups and things""");
+            directories.Should().BeEquivalentTo(new List<string>
+            {
+                Path.Combine(_mamePath, "vector"),
+                Path.Combine(_mamePath, "shmups and things")
+            });
+ 
+        }
+    }
+}

--- a/Mamesaver.Test/Mamesaver.Test.csproj
+++ b/Mamesaver.Test/Mamesaver.Test.csproj
@@ -58,7 +58,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Integration\GameListStoreTest.cs" />
+    <Compile Include="Integration\GameListStoreTests.cs" />
     <Compile Include="Integration\PowerTests.cs" />
     <Compile Include="Unit\HotKeyManagerTests.cs" />
     <Compile Include="Integration\SettingsStoreTests.cs" />

--- a/Mamesaver.Test/Mamesaver.Test.csproj
+++ b/Mamesaver.Test/Mamesaver.Test.csproj
@@ -59,6 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Integration\GameListStoreTests.cs" />
+    <Compile Include="Integration\MamePathManagerTests.cs" />
     <Compile Include="Integration\PowerTests.cs" />
     <Compile Include="Unit\HotKeyManagerTests.cs" />
     <Compile Include="Integration\SettingsStoreTests.cs" />

--- a/Mamesaver/ConfigForm.cs
+++ b/Mamesaver/ConfigForm.cs
@@ -234,7 +234,8 @@ namespace Mamesaver
             }
             catch (Exception)
             {
-                MessageBox.Show(@"Error running MAME; verify that the executable path is correct.", @"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(@"Error running MAME; verify that the executable path and configuration is correct.", @"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                Log.Error(ex, "Unable to construct game list");
                 e.Result = new List<SelectableGame>();
             }
         }

--- a/Mamesaver/ConfigForm.cs
+++ b/Mamesaver/ConfigForm.cs
@@ -9,9 +9,12 @@ using System.ComponentModel;
 using System.Windows.Forms;
 using System.Configuration;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using Mamesaver.Configuration;
 using Mamesaver.Configuration.Models;
+using Mamesaver.Extensions;
+using Serilog;
 using LayoutSettings = Mamesaver.Configuration.Models.LayoutSettings;
 
 namespace Mamesaver
@@ -232,7 +235,13 @@ namespace Mamesaver
                 var gamesList = _gameListBuilder.GetGameList(percentageComplete => ListBuilder.ReportProgress(percentageComplete));
                 e.Result = gamesList;
             }
-            catch (Exception)
+            catch (DirectoryNotFoundException de)
+            {
+                MessageBox.Show($@"Directory {de.GetPath()} not found.", @"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                Log.Error(de, "Unable to read directory");
+                e.Result = new List<SelectableGame>();
+            }
+            catch (Exception ex)
             {
                 MessageBox.Show(@"Error running MAME; verify that the executable path and configuration is correct.", @"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 Log.Error(ex, "Unable to construct game list");

--- a/Mamesaver/ContainerFactory.cs
+++ b/Mamesaver/ContainerFactory.cs
@@ -48,6 +48,7 @@ namespace Mamesaver
             container.Register<LayoutFactory>(Lifestyle.Singleton);
             container.Register<MameInvoker>(Lifestyle.Singleton);
             container.Register<PowerEventWatcher>(Lifestyle.Singleton);
+            container.Register<MamePathManager>(Lifestyle.Singleton);
 
             container.Register<IActivityHook>(() => new UserActivityHook(), Lifestyle.Singleton);
 

--- a/Mamesaver/Extensions/ExceptionExtensions.cs
+++ b/Mamesaver/Extensions/ExceptionExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.IO;
+
+namespace Mamesaver.Extensions
+{
+    public static class ExceptionExtensions
+    {
+        /// <summary>
+        ///     Extracts the path from a <see cref="DirectoryNotFoundException"/>
+        /// </summary>
+        public static string GetPath(this DirectoryNotFoundException e)
+        {
+            var pathMatcher = new System.Text.RegularExpressions.Regex(@"[^']+");
+            return pathMatcher.Matches(e.Message)[1].Value;
+        }
+    }
+}

--- a/Mamesaver/MamePathManager.cs
+++ b/Mamesaver/MamePathManager.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Mamesaver.Configuration.Models;
+
+namespace Mamesaver
+{
+   public class MamePathManager
+    {
+        /// <summary>
+        ///     String which is surrounded by double quotes
+        /// </summary>
+        private readonly Regex _quotedString = new Regex(@"^\""(.*)\""$");
+
+        private readonly Settings _settings;
+
+        public MamePathManager(Settings settings) => _settings = settings;
+
+        /// <summary>
+        ///     Parses a MAME configuration line into a collection of directories.
+        /// </summary>
+        /// <param name="key">Configuration key</param>
+        /// <param name="line">Entire configuration line to parse</param>
+        /// <returns>Absolute directories extracted from <see cref="line"/>, or <c>null</c> if no match</returns>
+        public List<string> ExtractConfigPaths(string key, string line)
+        {
+            // Skip lines which don't match the configuration key we are after
+            if (!Regex.IsMatch(line, ConfigurationLineRegex(key))) return null;
+
+            // Extract path string from configuration line
+            var directoryRegex = new Regex(ConfigurationLineRegex(key));
+            var match = directoryRegex.Match(line);
+
+            // Remove any speech marks around entire path collection and split into individual paths
+            var rawPaths = CleansePath(match.Groups[1].Value);
+            var paths = rawPaths.Split(';');
+
+            // Construct list of absolute paths
+            var absolutePaths = new List<string>();
+            foreach (var path in paths.Select(CleansePath))
+            {
+                // If path is absolute, add raw path
+                if (Path.IsPathRooted(path)) absolutePaths.Add(path);
+                else
+                {
+                    // If path is relative, construct absolute path relative to Mame executable
+                    var execPath = _settings.ExecutablePath;
+                    var workingDirectory = Directory.GetParent(execPath).ToString();
+
+                    absolutePaths.Add(Path.Combine(workingDirectory, path));
+                }
+            }
+
+            return absolutePaths;
+        }
+
+        /// <summary>
+        ///     Cleanses a single path or list of paths, trimming whitespace and removing surrounding speech marks. 
+        /// </summary>
+        public string CleansePath(string path)
+        {
+            path = path.Trim();
+
+            // Remove surrounding speech marks from path string. These are added by MAME if spaces are 
+            // present in any part of the path .
+            return _quotedString.IsMatch(path) ? _quotedString.Match(path).Groups[1].Value : path;
+        }
+
+        /// <summary>
+        ///    Returns a regular expression matching a MAME configuration line.
+        /// </summary>
+        /// <param name="key">MAME configuration key to patch</param>
+        /// <returns>Regex string</returns>
+        private static string ConfigurationLineRegex(string key) => $@"{key}\s+(.+)";
+    }
+}

--- a/Mamesaver/Mamesaver.csproj
+++ b/Mamesaver/Mamesaver.csproj
@@ -86,6 +86,7 @@
     <Compile Include="CaptureScreen.cs" />
     <Compile Include="ContainerFactory.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
+    <Compile Include="Extensions\ExceptionExtensions.cs" />
     <Compile Include="GamePlayManager.cs" />
     <Compile Include="Helper\StackHelper.cs" />
     <Compile Include="Hotkeys\HotKey.cs" />

--- a/Mamesaver/Mamesaver.csproj
+++ b/Mamesaver/Mamesaver.csproj
@@ -84,6 +84,7 @@
     <Compile Include="BlankScreen.cs" />
     <Compile Include="BlankScreenFactory.cs" />
     <Compile Include="CaptureScreen.cs" />
+    <Compile Include="MamePathManager.cs" />
     <Compile Include="ContainerFactory.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\ExceptionExtensions.cs" />


### PR DESCRIPTION
The primary fix for this PR is #34, however also fixes #35 and #36.

The output of `mame64.exe -showconfig` for a file path line results in the paths containing speech marks if:

- They are enclosed in speechmarks in `mame.ini`; or
- They contain spaces

For example, both of these examples result in speech marks:

- `rompath  roms;c:\my stuff\roms`
`rompath  "roms;c:\my stuff\roms"`

Note that the hybrid (and invalid) config line `rompath   roms;"c:\my stuff\roms"` is parsed by MAME, but the quoted value is silently ignored.

I have fixed handling of quotes and shifted the directory parsing code out of `GameListBuilder` and into a dedicated `MamePathManager` class, along with tests covering what is hopefully all permutations of valid path strings. I have also added logging for all of these parsing failures.

(apologies for the bogus branch name)